### PR TITLE
refac config: add concatenation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,14 @@ func main() {
 	})
 
 	fmt.Println(replacementMapSlugifier.Slugify("a b")) // Will print: hello-hi
+
+	concatenateMapSlugifier := slugify.New(slugify.Configuration{
+		ReplacementMap: map[rune]string{
+			'&': "et",
+		},
+		Concatenate: true,
+	})
+
+	fmt.Println(concatenateMapSlugifier.Slugify("Édouard & François")) // Will print: edouard-et-francois
 }
 ```

--- a/slugify.go
+++ b/slugify.go
@@ -70,6 +70,7 @@ type Configuration struct {
 	IsValidCharacterChecker func(rune) bool
 	ReplaceCharacter        rune
 	ReplacementMap          map[rune]string
+	Concatenate             bool
 }
 
 // New initialize a new slugifier
@@ -82,8 +83,8 @@ func New(config Configuration) *Slugifier {
 		config.ReplaceCharacter = '-'
 	}
 
-	if config.ReplacementMap == nil {
-		config.ReplacementMap = map[rune]string{
+	if config.ReplacementMap == nil || config.Concatenate {
+		replacementMap := map[rune]string{
 			'&': "and",
 			'@': "at",
 			'©': "c",
@@ -345,6 +346,14 @@ func New(config Configuration) *Slugifier {
 			'ỹ': "y",
 			'ỵ': "y",
 		}
+
+		if config.Concatenate {
+			for k, v := range config.ReplacementMap {
+				replacementMap[k] = v
+			}
+		}
+
+		config.ReplacementMap = replacementMap
 	}
 
 	return &Slugifier{

--- a/slugify_test.go
+++ b/slugify_test.go
@@ -89,6 +89,26 @@ func TestWithReplacementMap(t *testing.T) {
 	}
 }
 
+func TestWithConcatenation(t *testing.T) {
+	slugifier := New(Configuration{
+		ReplacementMap: map[rune]string{
+			'&': "et",
+		},
+		Concatenate: true,
+	})
+
+	results := make(map[string]string)
+	results["edouard-et-francois"] = "Édouard & François"
+
+	for slug, original := range results {
+		actual := slugifier.Slugify(original)
+
+		if actual != slug {
+			t.Errorf("Expected '%s', got: %s", slug, actual)
+		}
+	}
+}
+
 func BenchmarkSlugify(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Slugify("Hello, world!")


### PR DESCRIPTION
slugifier.replacementMap is private. In order to change only few fields
without copying all the map, a new config attribut is added.
If Concatenate is true, the given replacementMap is concatenated to the
default map.